### PR TITLE
fix: hide the diff button in read-only timeslider (#4)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@
 const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_timesliderEditbarRight = (hook_name, args, cb) => {
+  // The diff view relies on endpoints that the read-only timeslider cannot
+  // reach, so suppress the button entirely for read-only viewers (regression
+  // for #4). `renderContext.isReadOnly` is set by specialpages.ts when
+  // rendering `/p/:pad/timeslider`.
+  if (args.renderContext && args.renderContext.isReadOnly) return cb();
   args.content += eejs.require('ep_timesliderdiff/templates/timesliderDiff.ejs');
   cb();
 };

--- a/static/tests/backend/specs/readonly.js
+++ b/static/tests/backend/specs/readonly.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert').strict;
+const plugin = require('../../../..');
+
+describe(__filename, function () {
+  it('emits the diff button in a writable timeslider', function (done) {
+    const args = {content: '', renderContext: {isReadOnly: false}};
+    plugin.eejsBlock_timesliderEditbarRight('eejsBlock_timesliderEditbarRight', args, () => {
+      assert(args.content.includes('updateDiffView'),
+          `expected diff button to be emitted, got: ${args.content}`);
+      done();
+    });
+  });
+
+  it('does not emit the diff button in read-only mode (regression for #4)', function (done) {
+    const args = {content: '', renderContext: {isReadOnly: true}};
+    plugin.eejsBlock_timesliderEditbarRight('eejsBlock_timesliderEditbarRight', args, () => {
+      assert.equal(args.content, '',
+          `expected no button output in read-only mode, got: ${args.content}`);
+      done();
+    });
+  });
+
+  it('still works when renderContext is missing', function (done) {
+    const args = {content: ''};
+    plugin.eejsBlock_timesliderEditbarRight('eejsBlock_timesliderEditbarRight', args, () => {
+      assert(args.content.includes('updateDiffView'));
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #4: in read-only timeslider sessions the Diff View button appeared but did not work because it relied on endpoints/state not available to read-only viewers.
- Etherpad's \`specialpages.ts\` passes \`isReadOnly\` into the timeslider render context, and \`eejsBlock_*\` hooks receive that context via \`args.renderContext\`. Skip emitting the button when the viewer has read-only access.

## Test plan
- [x] New backend spec asserts the button is emitted normally, suppressed in read-only, and still emitted when renderContext is missing (defensive fallback).