### PR TITLE
fix: clamp diff popup to the viewport on long pads (#3)

### DIFF
--- a/static/css/diffview.css
+++ b/static/css/diffview.css
@@ -30,8 +30,7 @@ or implied, of Chas Emerick.
 table.diff {
 	border-collapse:collapse;
 	border:1px solid darkgray;
-	white-space:pre-wrap
-        height:400px;
+	white-space:pre-wrap;
 }
 table.diff tbody { 
 	font-family:Courier, monospace
@@ -90,4 +89,18 @@ tbody {
   height:400px;
   overflow:scroll;
   overflow-x:hidden;
+}
+
+/* Keep the diff popup inside the viewport on long pads — otherwise the
+   form (inline/try-again) gets pushed off the bottom and the user sees no
+   controls (#3). Clamp the popup to the viewport and let the content
+   scroll inside it. */
+.timesliderDiffSettings.popup.toolbar-popup {
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 80px);
+  box-sizing: border-box;
+  overflow: auto;
+}
+.timesliderDiffSettings.popup.toolbar-popup #timesliderDiffOutput {
+  max-width: 100%;
 }

--- a/static/tests/backend/specs/popup_overflow.js
+++ b/static/tests/backend/specs/popup_overflow.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const cssPath = path.resolve(__dirname, '..', '..', '..', '..', 'static', 'css', 'diffview.css');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(cssPath, 'utf8'); });
+
+  it('clamps the diff popup to the viewport (#3)', function () {
+    // Long pads previously pushed the popup beyond the viewport so the
+    // inline checkbox + "try again" button got clipped. The popup has to
+    // have both width and height caps and allow its own overflow so the
+    // controls stay reachable.
+    const popupBlock = src.match(
+        /\.timesliderDiffSettings\.popup\.toolbar-popup\s*\{([\s\S]*?)\}/);
+    assert(popupBlock, 'expected a rule block for .timesliderDiffSettings.popup.toolbar-popup');
+    const body = popupBlock[1];
+    assert(/max-width\s*:/.test(body), 'popup must declare max-width');
+    assert(/max-height\s*:/.test(body), 'popup must declare max-height');
+    assert(/overflow\s*:\s*auto/.test(body), 'popup must set overflow: auto so content scrolls');
+  });
+
+  it('does not leave a missing semicolon in the table.diff rule (#3)', function () {
+    const rule = src.match(/table\.diff\s*\{([\s\S]*?)\}/);
+    assert(rule, 'expected a rule for table.diff');
+    // The original source had `white-space:pre-wrap` with no trailing
+    // semicolon immediately followed by `height:400px;`, so the `height`
+    // declaration was lost to a CSS parse error. Every declaration inside
+    // the block must be terminated with ';'.
+    const body = rule[1].trim();
+    for (const line of body.split('\n').map((l) => l.trim()).filter(Boolean)) {
+      assert(line.endsWith(';') || line.endsWith('{') || line.endsWith('}'),
+          `every declaration in table.diff should end with a semicolon — saw: ${line}`);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3. Long pads used to push the diff popup past the viewport so the Inline-View checkbox and Try-Again button fell off the bottom. Clamp the popup to calc(100vw - 40px) / calc(100vh - 80px) with overflow:auto, so the body scrolls inside the popup instead. Also fixes a latent CSS parse error in the table.diff rule (missing semicolon). Backend spec enforces the caps and that every declaration terminates with a semicolon.