### PR TITLE
fix: stop hard-coding black text on the Diff View button (#5)

### DIFF
--- a/templates/timesliderDiff.ejs
+++ b/templates/timesliderDiff.ejs
@@ -1,8 +1,8 @@
 <ul>
   <li onclick='updateDiffView();$(".timesliderDiffSettings").toggleClass("popup-show");return false;'>
     <a id="exportlink" title="See the diff between this revision and the latest revision">
-      <div class="buttonicon" style="font-size:14px;color:black;width:80px;background-image:none;">
-        <u>Diff View</u>
+      <div class="buttonicon" style="font-size:14px;width:80px;background-image:none;">
+        Diff View
       </div>
     </a>
   </li>


### PR DESCRIPTION
Fixes #5. The button style baked `color: black` into the inline style, so the label always rendered in pure black regardless of the active theme — including dark skins where every other toolbar button uses a light text color. It also wrapped the label in a `<u>` that added an underline no other button has. Drop both overrides; the button now inherits the toolbar's text color.