### PR TITLE
refactor: adopt template helper with skip callback for eejsBlock_timesliderEditbarRight

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
 const eejs = require('ep_etherpad-lite/node/eejs');
 
-exports.eejsBlock_timesliderEditbarRight = (hook_name, args, cb) => {
-  // The diff view relies on endpoints that the read-only timeslider cannot
-  // reach, so suppress the button entirely for read-only viewers (regression
-  // for #4). `renderContext.isReadOnly` is set by specialpages.ts when
-  // rendering `/p/:pad/timeslider`.
-  if (args.renderContext && args.renderContext.isReadOnly) return cb();
-  args.content += eejs.require('ep_timesliderdiff/templates/timesliderDiff.ejs');
-  cb();
-};
+// The diff view relies on endpoints that the read-only timeslider cannot
+// reach, so suppress the button entirely for read-only viewers (regression
+// for #4). `renderContext.isReadOnly` is set by specialpages.ts when
+// rendering `/p/:pad/timeslider`.
+exports.eejsBlock_timesliderEditbarRight =
+    template('ep_timesliderdiff/templates/timesliderDiff.ejs', {
+      skip: (args) => args.renderContext && args.renderContext.isReadOnly,
+    });
 
 exports.eejsBlock_timesliderStyles = (hook_name, args, cb) => {
   args.content += '<link rel="stylesheet" ' +

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.0
+        version: 0.5.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -399,6 +403,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.2:
+    resolution: {integrity: sha512-6M0gYqRTaF2SnTvV1OiqOZQ4B37ZHL0Zjoz3/eOIAXeCEBA4jId62uz9uboLs87Qcfae7eirDYWpdir5u5zkEQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1672,6 +1680,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.2: {}
 
   es-abstract@1.24.2:
     dependencies:


### PR DESCRIPTION
Replaces hand-rolled `if (isReadOnly) return cb(); args.content += eejs.require(...); cb();` boilerplate with `template(path, {skip: (args) => args.renderContext?.isReadOnly})` from `ep_plugin_helpers`. Same runtime behavior.

Doesn't touch the other two hooks: `eejsBlock_timesliderStyles` is a raw `<link>` tag (not eejs), and `eejsBlock_timesliderBody` concatenates four `eejs.require` calls into one block — both stay hand-rolled.

Wave 3 of the Phase 4 template-helper sweep — the skip-callback variant.